### PR TITLE
Workaround para problema no parser da licença (Error: The description failed to render in the default format of reStructuredText.)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ setup(
     long_description_content_type='text/markdown',
     author=AUTHOR,
     author_email=AUTHOR_EMAIL,
-    license=read('LICENSE'),
+    license="GNU AFFERO GENERAL PUBLIC LICENSE",
     url=URL,
     packages=find_packages(exclude=["tests.*", "tests"]),
     package_data=find_package_data(PACKAGE, only_in_packages=False),


### PR DESCRIPTION
Conforme descrito [nessa issue](https://github.com/pypa/twine/issues/454#issuecomment-464077386) do projeto twine e [essa](https://github.com/pypa/setuptools/issues/1390#issuecomment-398098834) do projeto setuptools ao utilizar todo o conteúdo da licença no argumento do setup() pode ocorrer a quebra na criação do arquivo PKG-INFO, causando o parseamento errado do arquivo.

Por conta disso o twine falha ao checar o aquivo dist gerado:

Checking dist/libpythonprosfx-0.1.tar.gz: FAILED
long_description has syntax errors in markup and would not be rendered on PyPI.
line 8: Warning: Block quote ends without a blank line; unexpected unindent.
warning: long_description_content_type missing. defaulting to text/x-rst.

E o erro posterior no upload do pacote para o Pypi:

HTTPError: 400 Client Error: The description failed to render in the default format of reStructuredText.

A solução recomendada pelos desenvolveres é passar apenas uma string declarando o tipo de licença e o conteúdo da mesma ficar apenas no arquivo LICENSE como já está setado no projeto.

Com a mudança, o projeto sobe sem problemas.