### PR TITLE
Mudança de Título de ''Código Aberto' para 'OPEN SOURCE'

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Módulo para exemplificar construção de projetos Python no curso PyTools
 
-Nesse curso é ensinado como contribuir com projetos OPEN SOURCE.
+Nesse curso é ensinado como contribuir com projetos de Open Source.
 
 Link para o curso [Python Pro](https://pythonpro.com.br/)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Módulo para exemplificar construção de projetos Python no curso PyTools
 
-Nesse curso é ensinado como contribuir com projetos OPEN SOURCE.
+Nesse curso é ensinado como contribuir com projetos OPEN SOURCE
 
 Link para o curso [Python Pro](https://www.python.pro.br/)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Módulo para exemplificar construção de projetos Python no curso PyTools
 
-Nesse curso é ensinado como contribuir com projetos de código aberto
+Nesse curso é ensinado como contribuir com projetos OPEN SOURCE
 
 Link para o curso [Python Pro](https://www.python.pro.br/)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Módulo para exemplificar construção de projetos Python no curso PyTools
 
-Nesse curso é ensinado como contribuir com projetos OPEN SOURCE
+Nesse curso é ensinado como contribuir com projetos OPEN SOURCE.
 
 Link para o curso [Python Pro](https://www.python.pro.br/)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Módulo para exemplificar construção de projetos Python no curso PyTools
 
 Nesse curso é ensinado como contribuir com projetos OPEN SOURCE.
 
-Link para o curso [Python Pro](https://www.python.pro.br/)
+Link para o curso [Python Pro](https://pythonpro.com.br/)
 
 [![Build Status](https://travis-ci.org/pythonprobr/libpythonpro.svg?branch=master)](https://travis-ci.org/pythonprobr/libpythonpro)
 [![Updates](https://pyup.io/repos/github/pythonprobr/libpythonpro/shield.svg)](https://pyup.io/repos/github/pythonprobr/libpythonpro/)


### PR DESCRIPTION
Alterando contribuir projetos Código aberto para OPEN SOURCE, devido a OPEN SOURCE ser o termo a ser encontrado nos códigos público.
